### PR TITLE
feat: lazy import of semantic-release-plus

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,6 +1,5 @@
 import * as childProcess from 'child_process';
 import core from '@actions/core';
-import semanticReleasePlus from 'semantic-release-plus';
 import JSON5 from 'json5';
 import arrify from 'arrify';
 
@@ -108,12 +107,6 @@ async function run() {
 
   setGitConfigSafeDirectory();
 
-  // change working directory
-  if (workingDirectory) {
-    core.debug(`Changing working directory to: ${workingDirectory}`);
-    process.chdir(workingDirectory);
-  }
-
   // install additional plugins/configurations
   if (extendsInput) {
     additionalPackages.push(...arrify(extendsInput));
@@ -143,7 +136,14 @@ async function run() {
 
   core.debug(`options after cleanup: ${JSON.stringify(options)}`);
 
-  const result = await semanticReleasePlus(options);
+  // change working directory
+  if (workingDirectory) {
+    core.debug(`Changing working directory to: ${workingDirectory}`);
+    process.chdir(workingDirectory);
+  }
+
+  const semanticReleasePlus = await import('semantic-release-plus');
+  const result = await semanticReleasePlus.default(options);
   if (!result) {
     core.debug('No release published');
 


### PR DESCRIPTION
### Description
For project that are not node based the current approach requires you to have a package.json with your dependencies setup, or that you add these in the github workflow.

So I opted for instead supporting to do this via the `additional-packages` input instead by doing a lazy import.

In my use-case I have a `yaml` dependency in my `release.config.js`. Without the lazy import it would fail to run, because semantic-release-plus gets imported before `installPackages()` has run.
So by lazy loading it after the packages have been installed that use-case becomes supported.